### PR TITLE
chore: Prepare 2.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2.2.0 - 2024-07-17
+### Fixed
+- fix: Adjust package.json to make `build:doc` work again and fix incorrect URL
+- fix: Add example of `joinPaths` to README, remove non existing travis
+
+### Changed
+- Dependency updates
+- Update npm and node engines versions to current LTS
+- chore: Migrate to use Vite - drop Babel and Jest
+- ci: Update workflows from organization
+
 ## 2.1.0 – 2021-09-28
 ### Changed
 - Dependency updates

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/paths",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/paths",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
         "@nextcloud/browserslist-config": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/paths",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Helper functions for working with paths in Nextcloud apps",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## 2.2.0 - 2024-07-17
### Fixed
- fix: Adjust package.json to make `build:doc` work again and fix incorrect URL
- fix: Add example of `joinPaths` to README, remove non existing travis

### Changed
- Dependency updates
- Update npm and node engines versions to current LTS
- chore: Migrate to use Vite - drop Babel and Jest
- ci: Update workflows from organization