### PR TITLE
fix: Correctly setup Typescript root to emit declarations

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -6,7 +6,7 @@ SPDX-PackageSupplier = "Nextcloud GmbH <https://nextcloud.com/impressum/>"
 SPDX-PackageDownloadLocation = "https://github.com/nextcloud-libraries/nextcloud-paths"
 
 [[annotations]]
-path = ["package.json", "package-lock.json", "tsconfig.json"]
+path = ["package.json", "package-lock.json", "tsconfig.json", "test/tsconfig.json"]
 precedence = "aggregate"
 SPDX-FileCopyrightText = "2019 Nextcloud GmbH and Nextcloud contributors"
 SPDX-License-Identifier = "GPL-3.0-or-later"

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
       },
       "engines": {
         "node": "^20.0.0",
-        "npm": "^9.0.0 || ^10.0.0"
+        "npm": "^10.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "type": "git",
     "url": "https://github.com/nextcloud-libraries/nextcloud-paths"
   },
-  "author": "Christoph Wurst",
+  "author": "Nextcloud GmbH and Nextcloud contributors",
   "license": "GPL-3.0-or-later",
   "devDependencies": {
     "@nextcloud/browserslist-config": "^3.0.1",
@@ -44,10 +44,11 @@
   ],
   "engines": {
     "node": "^20.0.0",
-    "npm": "^9.0.0 || ^10.0.0"
+    "npm": "^10.0.0"
   },
   "files": [
     "dist",
+    "AUTHORS.md",
     "CHANGELOG.md",
     "README.md",
     "LICENSE"

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"extends": "..",
+	"include": ["../*.ts", ".", "../lib"],
+	"compilerOptions": {
+		"rootDir": ".."
+	}
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,14 +1,17 @@
 {
-    "compilerOptions": {
-        "target": "ESNext",
-        "module": "ESNext",
-        "moduleResolution": "Bundler",
-        "declaration": true,
-        "outDir": "./dist",
-        "strict": true,
-        "lib": [
-            "es6",
-            "dom"
-        ]
-    }
+	"include": ["lib"],
+	"compilerOptions": {
+		"target": "ESNext",
+		"module": "ESNext",
+		"moduleResolution": "Bundler",
+		"declaration": true,
+		"outDir": "./dist",
+		"rootDir": "lib",
+		"strict": true,
+		"lib": [
+			"es6",
+			"dom"
+		],
+		"types": ["vitest"]
+	}
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,23 +2,24 @@
  * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
+import { defineConfig } from "vitest/config";
 import viteConfig from "./vite.config";
 
 export default async (env: Parameters<typeof viteConfig>[0]) => {
 	const config =
 		typeof viteConfig === "function" ? await viteConfig(env) : viteConfig;
 
-	// node-externals conflicts with vitest
-	config.plugins = config.plugins!.filter(
-		(plugin) =>
-			plugin && (!("name" in plugin) || plugin?.name !== "node-externals")
-	);
-
-	config.test = {
-		coverage: {
-			reporter: ["text", "lcov"],
-		},
-	};
-
-	return config;
-};
+	return defineConfig({
+		...config,
+		// node-externals conflicts with vitest
+		plugins: config.plugins!.filter(
+			(plugin) =>
+				plugin && (!("name" in plugin) || plugin?.name !== "node-externals")
+		),
+		test: {
+			coverage: {
+				reporter: ["text", "lcov"],
+			},
+		}
+	})
+}


### PR DESCRIPTION
* Resolves https://github.com/nextcloud-libraries/nextcloud-upload/pull/1292#issuecomment-2238480355


Previously no root was set, so types for `vite.config` were included and the library types were emitted to `dist/lib`.

